### PR TITLE
관리자 페이지 : 유저 전체 조회 및 페이징 기능 추가, 광고 수신 동의여부 데이터 추가

### DIFF
--- a/src/main/java/repick/repickserver/domain/member/api/SignController.java
+++ b/src/main/java/repick/repickserver/domain/member/api/SignController.java
@@ -64,7 +64,7 @@ public class SignController {
     @Operation(summary = "전체 유저 조회하기 (최신순)")
     @GetMapping("/admin/latest")
     public ResponseEntity<List<SignUserInfoResponse>> getLatestUsers(@Parameter(description = "1번째 페이지 조회시 null," +
-            " 2번째 이상 페이지 조회시 직전 페이지의 마지막 product id") @RequestParam(required = false) Long cursorId,
+            " 2번째 이상 페이지 조회시 직전 페이지의 마지막 member id") @RequestParam(required = false) Long cursorId,
                                                                      @Parameter(description = "한 페이지에 가져올 유저 개수") @RequestParam int pageSize) {
         return ResponseEntity.ok()
                 .body(memberService.getUserInfoPage(cursorId, pageSize));

--- a/src/main/java/repick/repickserver/domain/member/api/SignController.java
+++ b/src/main/java/repick/repickserver/domain/member/api/SignController.java
@@ -2,6 +2,7 @@ package repick.repickserver.domain.member.api;
 
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,6 +14,7 @@ import repick.repickserver.domain.member.dto.SignUserInfoResponse;
 import springfox.documentation.annotations.ApiIgnore;
 
 import javax.servlet.http.HttpServletResponse;
+import java.util.List;
 
 @RestController
 @RequestMapping("/sign")
@@ -59,21 +61,12 @@ public class SignController {
                 .body(memberService.update(request, token));
     }
 
-    /*
-
-    !! DEPRECATED !!
-    개발용으로 더이상 사용하지 않는 메서드입니다.
-
-    @GetMapping("/user/get")
-    public ResponseEntity<SignResponse> getUser(@RequestParam String email) {
+    @Operation(summary = "전체 유저 조회하기 (최신순)")
+    @GetMapping("/admin/latest")
+    public ResponseEntity<List<SignUserInfoResponse>> getLatestUsers(@Parameter(description = "1번째 페이지 조회시 null," +
+            " 2번째 이상 페이지 조회시 직전 페이지의 마지막 product id") @RequestParam(required = false) Long cursorId,
+                                                                     @Parameter(description = "한 페이지에 가져올 유저 개수") @RequestParam int pageSize) {
         return ResponseEntity.ok()
-                .body(memberService.getMember(email));
+                .body(memberService.getUserInfoPage(cursorId, pageSize));
     }
-
-    @GetMapping("/admin/get")
-    public ResponseEntity<SignResponse> getUserForAdmin(@RequestParam String email) {
-        return ResponseEntity.ok()
-                .body(memberService.getMember(email));
-    }
-    */
 }

--- a/src/main/java/repick/repickserver/domain/member/application/KakaoUserService.java
+++ b/src/main/java/repick/repickserver/domain/member/application/KakaoUserService.java
@@ -176,6 +176,8 @@ public class KakaoUserService {
                     .nickname(nickname)
                     .password(encodedPassword)
                     .role(Role.USER)
+                    // 광고 메세지 수신 동의 여부는 기본값 false
+                    .allowMarketingMessages(false)
                     .build();
 
             memberRepository.save(kakaoUser);

--- a/src/main/java/repick/repickserver/domain/member/application/MemberService.java
+++ b/src/main/java/repick/repickserver/domain/member/application/MemberService.java
@@ -20,6 +20,8 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 import javax.transaction.Transactional;
 
+import java.util.List;
+
 import static repick.repickserver.global.error.exception.ErrorCode.MEMBER_NOT_FOUND;
 import static repick.repickserver.global.error.exception.ErrorCode.TOKEN_EXPIRED;
 
@@ -99,4 +101,7 @@ public class MemberService {
         return jwtProvider.createAccessToken(new UserDetailsImpl(member));
     }
 
+    public List<SignUserInfoResponse> getUserInfoPage(Long cursorId, int pageSize) {
+        return memberRepository.findPage(cursorId, pageSize);
+    }
 }

--- a/src/main/java/repick/repickserver/domain/member/domain/Member.java
+++ b/src/main/java/repick/repickserver/domain/member/domain/Member.java
@@ -34,6 +34,9 @@ public class Member extends BaseTimeEntity {
     private Address address;
     @Embedded
     private Bank bank;
+    private Boolean allowMarketingMessages;
+
+
 
     public void update(Member member) {
         this.email = member.getEmail();
@@ -43,6 +46,7 @@ public class Member extends BaseTimeEntity {
         this.phoneNumber = member.getPhoneNumber();
         this.address = member.getAddress();
         this.bank = member.getBank();
+        this.allowMarketingMessages = member.getAllowMarketingMessages();
     }
 
 

--- a/src/main/java/repick/repickserver/domain/member/dto/SignLoginResponse.java
+++ b/src/main/java/repick/repickserver/domain/member/dto/SignLoginResponse.java
@@ -22,6 +22,7 @@ public class SignLoginResponse {
     private String phoneNumber;
     private Address address;
     private Bank bank;
+    private Boolean allowMarketingMessages;
     @Schema(description = "엑세스 토큰")
     private String accessToken;
     @Schema(description = "리프레쉬 토큰")

--- a/src/main/java/repick/repickserver/domain/member/dto/SignUpdateRequest.java
+++ b/src/main/java/repick/repickserver/domain/member/dto/SignUpdateRequest.java
@@ -22,4 +22,5 @@ public class SignUpdateRequest {
     private String phoneNumber;
     private Address address;
     private Bank bank;
+    private Boolean allowMarketingMessages;
 }

--- a/src/main/java/repick/repickserver/domain/member/dto/SignUserInfoResponse.java
+++ b/src/main/java/repick/repickserver/domain/member/dto/SignUserInfoResponse.java
@@ -22,5 +22,6 @@ public class SignUserInfoResponse { // SignUpdateResponse 도 이걸로 대체
     private String phoneNumber;
     private Address address;
     private Bank bank;
+    private Boolean allowMarketingMessages;
 
 }

--- a/src/main/java/repick/repickserver/domain/member/dto/SignUserInfoResponse.java
+++ b/src/main/java/repick/repickserver/domain/member/dto/SignUserInfoResponse.java
@@ -1,15 +1,18 @@
 package repick.repickserver.domain.member.dto;
 
+import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
+import repick.repickserver.domain.member.domain.Member;
 import repick.repickserver.domain.model.Address;
 import repick.repickserver.domain.member.domain.Role;
 import repick.repickserver.domain.model.Bank;
 
 
 @Getter
-@Builder @AllArgsConstructor @NoArgsConstructor
+@AllArgsConstructor @NoArgsConstructor
 public class SignUserInfoResponse { // SignUpdateResponse 도 이걸로 대체
+    private Long id;
     @Schema(description = "닉네임", example = "tester")
     private String nickname;
     @Schema(description = "실명", example = "김리픽")
@@ -23,5 +26,17 @@ public class SignUserInfoResponse { // SignUpdateResponse 도 이걸로 대체
     private Address address;
     private Bank bank;
     private Boolean allowMarketingMessages;
+
+    @Builder @QueryProjection
+    public SignUserInfoResponse(Member member) {
+        this.id = member.getId();
+        this.nickname = member.getNickname();
+        this.name = member.getName();
+        this.email = member.getEmail();
+        this.phoneNumber = member.getPhoneNumber();
+        this.address = member.getAddress();
+        this.bank = member.getBank();
+        this.allowMarketingMessages = member.getAllowMarketingMessages();
+    }
 
 }

--- a/src/main/java/repick/repickserver/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/repick/repickserver/domain/member/mapper/MemberMapper.java
@@ -17,6 +17,9 @@ public class MemberMapper {
     private final PasswordEncoder passwordEncoder;
 
     public Member registerRequestToMember(SignUpdateRequest request) {
+
+        if (request.getAllowMarketingMessages() == null) request.setAllowMarketingMessages(false);
+
         return Member.builder()
                 .userId(UUID.randomUUID().toString())
                 .password(passwordEncoder.encode(request.getPassword()))
@@ -27,6 +30,7 @@ public class MemberMapper {
                 .address(request.getAddress())
                 .bank(request.getBank())
                 .role(Role.USER)
+                .allowMarketingMessages(request.getAllowMarketingMessages())
                 .build();
     }
 
@@ -53,6 +57,7 @@ public class MemberMapper {
                 .phoneNumber(member.getPhoneNumber())
                 .address(member.getAddress())
                 .bank(member.getBank())
+                .allowMarketingMessages(member.getAllowMarketingMessages())
                 .build();
     }
 
@@ -66,6 +71,7 @@ public class MemberMapper {
         memberBuilder.phoneNumber(request.getPhoneNumber() != null ? request.getPhoneNumber() : member.getPhoneNumber());
         memberBuilder.address(request.getAddress() != null ? request.getAddress() : member.getAddress());
         memberBuilder.bank(request.getBank() != null ? request.getBank() : member.getBank());
+        memberBuilder.allowMarketingMessages(request.getAllowMarketingMessages() != null ? request.getAllowMarketingMessages() : member.getAllowMarketingMessages());
 
         return memberBuilder.build();
     }

--- a/src/main/java/repick/repickserver/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/repick/repickserver/domain/member/mapper/MemberMapper.java
@@ -50,15 +50,7 @@ public class MemberMapper {
 
     public SignUserInfoResponse toSignUserInfoResponse(Member member) {
         return SignUserInfoResponse.builder()
-                .name(member.getName())
-                .email(member.getEmail())
-                .nickname(member.getNickname())
-                .role(member.getRole())
-                .phoneNumber(member.getPhoneNumber())
-                .address(member.getAddress())
-                .bank(member.getBank())
-                .allowMarketingMessages(member.getAllowMarketingMessages())
-                .build();
+                .member(member).build();
     }
 
     public Member mapRequestToMember(Member member, SignUpdateRequest request) {

--- a/src/main/java/repick/repickserver/domain/member/repository/MemberRepository.java
+++ b/src/main/java/repick/repickserver/domain/member/repository/MemberRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 @Transactional
 @Repository
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
     Optional<Member> findByEmail(@Param("email") String email);
     Optional<Member> findByNickname(@Param("nickname") String nickname);
     Optional<Member> findByUserId(String userId);

--- a/src/main/java/repick/repickserver/domain/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/repick/repickserver/domain/member/repository/MemberRepositoryCustom.java
@@ -1,0 +1,9 @@
+package repick.repickserver.domain.member.repository;
+
+import repick.repickserver.domain.member.dto.SignUserInfoResponse;
+
+import java.util.List;
+
+public interface MemberRepositoryCustom {
+    List<SignUserInfoResponse> findPage(Long cursorId, int pageSize);
+}

--- a/src/main/java/repick/repickserver/domain/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/repick/repickserver/domain/member/repository/MemberRepositoryImpl.java
@@ -1,0 +1,32 @@
+package repick.repickserver.domain.member.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import repick.repickserver.domain.member.dto.QSignUserInfoResponse;
+import repick.repickserver.domain.member.dto.SignUserInfoResponse;
+
+import java.util.List;
+
+import static repick.repickserver.domain.member.domain.QMember.member;
+
+@RequiredArgsConstructor
+public class MemberRepositoryImpl implements MemberRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<SignUserInfoResponse> findPage(Long cursorId, int pageSize) {
+        return jpaQueryFactory
+                .select(new QSignUserInfoResponse(member))
+                .from(member)
+                .where(ltMemberId(cursorId))
+                .orderBy(member.id.desc())
+                .limit(pageSize)
+                .fetch();
+    }
+
+    private BooleanExpression ltMemberId(Long cursorId) { // 첫 페이지 조회와 두번째 이상 페이지 조회를 구분하기 위함
+        return cursorId != null ? member.id.lt(cursorId) : null;
+    }
+}


### PR DESCRIPTION
# 관리자 페이지 : 유저 조회 API
메서드 : GET
경로 : /api/sign/admin/latest
쿼리 파라미터 : 
1. cursorId : 첫번째 페이지 조회시 null, 다음 페이지 조회시 직전 페이지의 memberId
2. pageSize : 한 페이지에 조회되는 데이터 수 